### PR TITLE
fix: subprocess Text=True isn't valid on older versions of Python

### DIFF
--- a/.build/PuppetPython/common.py
+++ b/.build/PuppetPython/common.py
@@ -412,7 +412,7 @@ def set_puppet_config_option(config_options, config_file_path=None, section="age
             section,
         ]
 
-        result = subprocess.run(command, capture_output=True, text=True)
+        result = subprocess.run(command, capture_output=True, universal_newlines=True)
 
         if result.returncode != 0:
             raise Exception(
@@ -433,7 +433,7 @@ def enable_puppet_service():
 # Function to check if the user wants to change the hostname
 def check_hostname_change():
     try:
-        current_hostname = subprocess.check_output(["hostname"], text=True).strip()
+        current_hostname = subprocess.check_output(["hostname"], universal_newlines=True).strip()
     except subprocess.CalledProcessError as e:
         print(f"Error: {e}")
         sys.exit(1)

--- a/.build/PuppetPython/puppet_agent.py
+++ b/.build/PuppetPython/puppet_agent.py
@@ -195,7 +195,7 @@ def main():
             )
             sys.exit(1)
 
-    current_hostname = subprocess.check_output(["hostname"], text=True).strip()
+    current_hostname = subprocess.check_output(["hostname"], universal_newlines=True).strip()
     new_hostname = current_hostname
 
     # If the environment is set to the default of production then check if the user wants to change it

--- a/.build/PuppetPython/puppet_server.py
+++ b/.build/PuppetPython/puppet_server.py
@@ -446,7 +446,7 @@ def main():
         sys.exit(1)
 
     # Get the current hostname
-    current_hostname = subprocess.check_output(["hostname"], text=True).strip()
+    current_hostname = subprocess.check_output(["hostname"], universal_newlines=True).strip()
 
     # Print out a welcome message
     print_welcome(app)

--- a/bootstrap_puppet-linux.py
+++ b/bootstrap_puppet-linux.py
@@ -414,7 +414,7 @@ def set_puppet_config_option(config_options, config_file_path=None, section="age
             section,
         ]
 
-        result = subprocess.run(command, capture_output=True, text=True)
+        result = subprocess.run(command, capture_output=True, universal_newlines=True)
 
         if result.returncode != 0:
             raise Exception(
@@ -435,7 +435,7 @@ def enable_puppet_service():
 # Function to check if the user wants to change the hostname
 def check_hostname_change():
     try:
-        current_hostname = subprocess.check_output(["hostname"], text=True).strip()
+        current_hostname = subprocess.check_output(["hostname"], universal_newlines=True).strip()
     except subprocess.CalledProcessError as e:
         print(f"Error: {e}")
         sys.exit(1)
@@ -651,7 +651,7 @@ def main():
             )
             sys.exit(1)
 
-    current_hostname = subprocess.check_output(["hostname"], text=True).strip()
+    current_hostname = subprocess.check_output(["hostname"], universal_newlines=True).strip()
     new_hostname = current_hostname
 
     # If the environment is set to the default of production then check if the user wants to change it

--- a/bootstrap_puppet-server.py
+++ b/bootstrap_puppet-server.py
@@ -414,7 +414,7 @@ def set_puppet_config_option(config_options, config_file_path=None, section="age
             section,
         ]
 
-        result = subprocess.run(command, capture_output=True, text=True)
+        result = subprocess.run(command, capture_output=True, universal_newlines=True)
 
         if result.returncode != 0:
             raise Exception(
@@ -435,7 +435,7 @@ def enable_puppet_service():
 # Function to check if the user wants to change the hostname
 def check_hostname_change():
     try:
-        current_hostname = subprocess.check_output(["hostname"], text=True).strip()
+        current_hostname = subprocess.check_output(["hostname"], universal_newlines=True).strip()
     except subprocess.CalledProcessError as e:
         print(f"Error: {e}")
         sys.exit(1)
@@ -902,7 +902,7 @@ def main():
         sys.exit(1)
 
     # Get the current hostname
-    current_hostname = subprocess.check_output(["hostname"], text=True).strip()
+    current_hostname = subprocess.check_output(["hostname"], universal_newlines=True).strip()
 
     # Print out a welcome message
     print_welcome(app)


### PR DESCRIPTION
I got caught out by copilot adding parameters that are too new for most versions of Python.
Revert to older parameters.