### PR TITLE
Persist Linux hostname to disk

### DIFF
--- a/bootstrap_puppet-linux.py
+++ b/bootstrap_puppet-linux.py
@@ -455,6 +455,8 @@ def set_hostname(new_hostname):
     log.info(f"Setting the hostname to {new_hostname}")
     try:
         subprocess.run(["hostname", new_hostname], check=True)
+        with open("/etc/hostname", "w") as hostname_file:
+            hostname_file.write(new_hostname)
     except subprocess.CalledProcessError as e:
         print_error(f"Failed to set hostname. Error: {e}")
         sys.exit(1)


### PR DESCRIPTION
Just calling `hostname` only changes the hostname for the active session. We also need to write it to /etc/hostname for it to persist across reboots.