### PR TITLE
fix: CSR extensions prompt on Windows

### DIFF
--- a/bootstrap_puppet-windows.ps1
+++ b/bootstrap_puppet-windows.ps1
@@ -248,6 +248,7 @@ function Get-CSRAttributes
         $CSRExtensions.Add($KeyName, $Value)
         $Continue = Get-Response 'Would you like to add another key? [y]es/[n]o' 'bool'
     }
+    return $CSRExtensions
 }
 
 function Set-CertificateExtensions


### PR DESCRIPTION
When running on Windows the CSR extensions prompt didn't return a value.

This fixes that.